### PR TITLE
Add loading state indicators and widen color grid layout

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import { Form, useLoaderData } from "react-router";
+import { Form, useLoaderData, useNavigation } from "react-router";
 import { useEffect, useMemo, useState } from "react";
 
 import type { Route } from "./+types/_index";
@@ -83,6 +83,8 @@ export default function Index() {
   const { segments, saturation, lightness, error } = useLoaderData<LoaderData>();
   const [sValue, setSValue] = useState(saturation);
   const [lValue, setLValue] = useState(lightness);
+  const navigation = useNavigation();
+  const isUpdatingSwatches = navigation.state !== "idle";
 
   useEffect(() => {
     setSValue(saturation);
@@ -109,7 +111,7 @@ export default function Index() {
   }, [segments]);
 
   return (
-    <main className="mx-auto max-w-5xl px-4 py-12 sm:px-6 lg:px-8">
+    <main className="mx-auto w-full max-w-screen-2xl px-4 py-12 sm:px-6 lg:px-10">
       <header className="mb-10 flex flex-col gap-2">
         <h1 className="text-3xl font-semibold tracking-tight text-slate-100 sm:text-4xl">
           Color Swatcher
@@ -205,9 +207,32 @@ export default function Index() {
           </span>
           <button
             type="submit"
-            className="rounded-md bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-900 shadow hover:bg-white focus:outline-none focus:ring-2 focus:ring-slate-200"
+            disabled={isUpdatingSwatches}
+            className="flex items-center gap-2 rounded-md bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-900 shadow transition-colors hover:bg-white focus:outline-none focus:ring-2 focus:ring-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
           >
-            Update swatches
+            {isUpdatingSwatches && (
+              <svg
+                className="h-4 w-4 animate-spin text-slate-900"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <circle
+                  className="opacity-20"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                  fill="none"
+                />
+                <path
+                  className="opacity-90"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 0 1 8-8v4a4 4 0 0 0-4 4H4z"
+                />
+              </svg>
+            )}
+            {isUpdatingSwatches ? "Loading" : "Update swatches"}
           </button>
         </div>
       </Form>
@@ -226,41 +251,74 @@ export default function Index() {
           </p>
         )}
 
-        <div className="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {swatches.map((segment) => {
-            const {
-              color: { name, rgb, hsl },
-            } = segment;
-            const textClass = luminanceTextClass(rgb);
+        <div
+          className="relative mt-6"
+          aria-live="polite"
+          aria-busy={isUpdatingSwatches}
+        >
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+            {swatches.map((segment) => {
+              const {
+                color: { name, rgb, hsl },
+              } = segment;
+              const textClass = luminanceTextClass(rgb);
 
-            return (
-              <article
-                key={name}
-                className="overflow-hidden rounded-xl border border-white/10 shadow-lg"
-              >
-                <div
-                  className={`p-6 transition-colors duration-300 ${textClass}`}
-                  style={{ backgroundColor: rgb.value }}
+              return (
+                <article
+                  key={name}
+                  className="overflow-hidden rounded-xl border border-white/10 shadow-lg"
                 >
-                  <h3 className="text-lg font-semibold">{name}</h3>
-                  <dl className="mt-4 space-y-2 text-sm">
-                    <div className="flex justify-between gap-4">
-                      <dt className="font-medium uppercase tracking-wide opacity-80">
-                        RGB
-                      </dt>
-                      <dd className="font-mono">{rgb.value}</dd>
-                    </div>
-                    <div className="flex justify-between gap-4">
-                      <dt className="font-medium uppercase tracking-wide opacity-80">
-                        HSL
-                      </dt>
-                      <dd className="font-mono">{hsl.value}</dd>
-                    </div>
-                  </dl>
-                </div>
-              </article>
-            );
-          })}
+                  <div
+                    className={`p-6 transition-colors duration-300 ${textClass}`}
+                    style={{ backgroundColor: rgb.value }}
+                  >
+                    <h3 className="text-lg font-semibold">{name}</h3>
+                    <dl className="mt-4 space-y-2 text-sm">
+                      <div className="flex justify-between gap-4">
+                        <dt className="font-medium uppercase tracking-wide opacity-80">
+                          RGB
+                        </dt>
+                        <dd className="font-mono">{rgb.value}</dd>
+                      </div>
+                      <div className="flex justify-between gap-4">
+                        <dt className="font-medium uppercase tracking-wide opacity-80">
+                          HSL
+                        </dt>
+                        <dd className="font-mono">{hsl.value}</dd>
+                      </div>
+                    </dl>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+          {isUpdatingSwatches && (
+            <div className="absolute inset-0 flex items-center justify-center rounded-xl border border-white/5 bg-slate-950/60 backdrop-blur-sm">
+              <div className="flex items-center gap-3 text-sm font-medium text-slate-200">
+                <svg
+                  className="h-5 w-5 animate-spin text-slate-200"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                    fill="none"
+                  />
+                  <path
+                    className="opacity-90"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 0 1 8-8v4a4 4 0 0 0-4 4H4z"
+                  />
+                </svg>
+                Updating swatches…
+              </div>
+            </div>
+          )}
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- add a loading indicator that disables the swatch update button and overlays the grid during requests
- widen the swatch grid layout and add extra responsive breakpoints so the colors fill more of the screen width

## Testing
- npm test *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68db97dda7c0832fb3bedb15bee1612e