### PR TITLE
Refactor server utilities and shared types

### DIFF
--- a/app/lib/__tests__/segmentHueSpace.test.ts
+++ b/app/lib/__tests__/segmentHueSpace.test.ts
@@ -1,18 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import type { ColorDescriptor } from "../colorApi.server";
+import type { ColorDescriptor } from "../types.server";
 import { segmentHueSpace } from "../segmentHueSpace.server";
+import { normalizeHue } from "../utils.server";
 
 interface FakeRange {
   readonly start: number;
   readonly end: number;
   readonly name: string;
 }
-
-const normalizeHue = (hue: number): number => {
-  const wrapped = hue % 360;
-  return wrapped < 0 ? wrapped + 360 : wrapped;
-};
 
 const createFakeSampler = (ranges: FakeRange[]) => {
   return async (hue: number): Promise<ColorDescriptor> => {

--- a/app/lib/adaptiveSampler.server.ts
+++ b/app/lib/adaptiveSampler.server.ts
@@ -1,0 +1,49 @@
+import type { ColorDescriptor } from "./types.server";
+import { normalizeHue } from "./utils.server";
+
+export class AdaptiveSampler {
+  private readonly fetcher: (hue: number) => Promise<ColorDescriptor>;
+
+  private readonly promises = new Map<number, Promise<ColorDescriptor>>();
+
+  private readonly values = new Map<number, ColorDescriptor>();
+
+  constructor(fetcher: (hue: number) => Promise<ColorDescriptor>) {
+    this.fetcher = fetcher;
+  }
+
+  private keyFor(hue: number): number {
+    const normalized = normalizeHue(hue);
+    return Number(normalized.toFixed(6));
+  }
+
+  async get(hue: number): Promise<ColorDescriptor> {
+    const key = this.keyFor(hue);
+    const existing = this.promises.get(key);
+    if (existing) {
+      return existing;
+    }
+
+    const promise = this.fetcher(normalizeHue(hue)).then((value) => {
+      this.values.set(key, value);
+      return value;
+    });
+
+    this.promises.set(key, promise);
+
+    try {
+      return await promise;
+    } catch (error) {
+      this.promises.delete(key);
+      throw error;
+    }
+  }
+
+  getCached(hue: number): ColorDescriptor | undefined {
+    return this.values.get(this.keyFor(hue));
+  }
+
+  getKnownHues(): number[] {
+    return Array.from(this.values.keys()).sort((a, b) => a - b);
+  }
+}

--- a/app/lib/colorApi.server.ts
+++ b/app/lib/colorApi.server.ts
@@ -1,21 +1,8 @@
+import type { ColorDescriptor, GetColorByHslOptions } from "./types.server";
+import { normalizeHue } from "./utils.server";
+
 // Base endpoint documented by The Color API for looking up an HSL tuple.
 const COLOR_API_ENDPOINT = "https://www.thecolorapi.com/id";
-
-export interface ColorDescriptor {
-  readonly name: string;
-  readonly rgb: {
-    readonly value: string;
-    readonly r: number;
-    readonly g: number;
-    readonly b: number;
-  };
-  readonly hsl: {
-    readonly value: string;
-    readonly h: number;
-    readonly s: number;
-    readonly l: number;
-  };
-}
 
 interface ColorApiResponse {
   readonly name: { readonly value: string };
@@ -33,12 +20,6 @@ interface ColorApiResponse {
   };
 }
 
-export interface GetColorByHslOptions {
-  readonly hue: number;
-  readonly saturation: number;
-  readonly lightness: number;
-}
-
 // Guard against out-of-band saturation/lightness values before building the URL.
 const clampPercentage = (value: number): number => {
   if (Number.isNaN(value)) {
@@ -54,20 +35,6 @@ const clampPercentage = (value: number): number => {
   }
 
   return value;
-};
-
-// Convert arbitrary hue input into the `[0, 360)` range expected by the API.
-const normalizeHue = (hue: number): number => {
-  if (!Number.isFinite(hue)) {
-    return 0;
-  }
-
-  const wrapped = hue % 360;
-  if (wrapped < 0) {
-    return wrapped + 360;
-  }
-
-  return wrapped;
 };
 
 // Query The Color API for a single color description at the provided HSL triplet.
@@ -115,4 +82,3 @@ export async function getColorByHsl({
   } satisfies ColorDescriptor;
 }
 
-export type { ColorDescriptor as ColorSample };

--- a/app/lib/types.server.ts
+++ b/app/lib/types.server.ts
@@ -1,0 +1,35 @@
+export interface ColorDescriptor {
+  readonly name: string;
+  readonly rgb: {
+    readonly value: string;
+    readonly r: number;
+    readonly g: number;
+    readonly b: number;
+  };
+  readonly hsl: {
+    readonly value: string;
+    readonly h: number;
+    readonly s: number;
+    readonly l: number;
+  };
+}
+
+export interface GetColorByHslOptions {
+  readonly hue: number;
+  readonly saturation: number;
+  readonly lightness: number;
+}
+
+export interface HueSegment {
+  readonly startHue: number;
+  readonly endHue: number;
+  readonly color: ColorDescriptor;
+}
+
+export interface SegmentHueSpaceOptions {
+  readonly saturation: number;
+  readonly lightness: number;
+  readonly sample?: (hue: number) => Promise<ColorDescriptor>;
+}
+
+export type ColorSample = ColorDescriptor;

--- a/app/lib/utils.server.ts
+++ b/app/lib/utils.server.ts
@@ -1,0 +1,13 @@
+export const normalizeHue = (hue: number): number => {
+  if (!Number.isFinite(hue)) {
+    return 0;
+  }
+
+  const wrapped = hue % 360;
+
+  if (Number.isNaN(wrapped)) {
+    return 0;
+  }
+
+  return wrapped < 0 ? wrapped + 360 : wrapped;
+};


### PR DESCRIPTION
## Summary
- extract shared server types and utilities into dedicated modules
- move the adaptive sampler to its own module and reuse it in hue segmentation
- remove the unused segment cache clearing helper and update tests to use shared hue normalization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68db9b464b4c832fbcd7761de31b6f28