### PR TITLE
Add dirty state to swatch update controls

### DIFF
--- a/app/components/SwatchControls.tsx
+++ b/app/components/SwatchControls.tsx
@@ -13,6 +13,7 @@ interface SwatchControlsProps {
   readonly defaultSaturation: number;
   readonly defaultLightness: number;
   readonly isUpdating: boolean;
+  readonly isDirty: boolean;
 }
 
 export function SwatchControls({
@@ -25,6 +26,7 @@ export function SwatchControls({
   defaultSaturation,
   defaultLightness,
   isUpdating,
+  isDirty,
 }: SwatchControlsProps) {
   return (
     <Form method="get" className="grid gap-8 rounded-xl border border-white/10 bg-slate-900/40 p-6 shadow-xl backdrop-blur">
@@ -100,7 +102,7 @@ export function SwatchControls({
         </span>
         <button
           type="submit"
-          disabled={isUpdating}
+          disabled={!isDirty || isUpdating}
           className="flex items-center gap-2 rounded-md bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-900 shadow transition-colors hover:bg-white focus:outline-none focus:ring-2 focus:ring-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {isUpdating && (

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -34,6 +34,7 @@ export default function Index() {
   const [lValue, setLValue] = useState(lightness);
   const navigation = useNavigation();
   const isUpdatingSwatches = navigation.state !== "idle";
+  const hasPendingChanges = sValue !== saturation || lValue !== lightness;
 
   useEffect(() => {
     setSValue(saturation);
@@ -83,6 +84,7 @@ export default function Index() {
         defaultSaturation={DEFAULT_SATURATION}
         defaultLightness={DEFAULT_LIGHTNESS}
         isUpdating={isUpdatingSwatches}
+        isDirty={hasPendingChanges}
       />
 
       <SwatchesSection


### PR DESCRIPTION
## Summary
- track pending saturation and lightness changes in the index route
- disable the Update swatches button until a control value changes and keep it disabled while updating

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcb19ac5a0832faa89dc0e8456789d