### PR TITLE
Stream hue segmentation updates

### DIFF
--- a/app/components/SwatchesSection.tsx
+++ b/app/components/SwatchesSection.tsx
@@ -6,6 +6,7 @@ interface SwatchesSectionProps {
   readonly swatches: HueSegment[];
   readonly error: string | null;
   readonly isUpdating: boolean;
+  readonly showOverlay: boolean;
 }
 
 const swatchCountMessage = (count: number): string => {
@@ -16,7 +17,12 @@ const swatchCountMessage = (count: number): string => {
   return `${count} unique color names were found for this S/L combination.`;
 };
 
-export function SwatchesSection({ swatches, error, isUpdating }: SwatchesSectionProps) {
+export function SwatchesSection({
+  swatches,
+  error,
+  isUpdating,
+  showOverlay,
+}: SwatchesSectionProps) {
   return (
     <section className="mt-12">
       <h2 className="text-xl font-semibold text-slate-100">Distinct names</h2>
@@ -34,7 +40,7 @@ export function SwatchesSection({ swatches, error, isUpdating }: SwatchesSection
             <SwatchCard key={segment.color.name} segment={segment} />
           ))}
         </div>
-        {isUpdating && (
+        {showOverlay && (
           <div className="absolute inset-0 flex items-center justify-center rounded-xl border border-white/5 bg-slate-950/60 backdrop-blur-sm">
             <div className="flex items-center gap-3 text-sm font-medium text-slate-200">
               <svg className="h-5 w-5 animate-spin text-slate-200" viewBox="0 0 24 24" aria-hidden="true">

--- a/app/components/__tests__/SwatchesSection.test.tsx
+++ b/app/components/__tests__/SwatchesSection.test.tsx
@@ -21,7 +21,14 @@ describe("SwatchesSection", () => {
   it("renders the provided swatches", () => {
     const swatches = [createSwatch("Red"), createSwatch("Blue"), createSwatch("Green")];
 
-    render(<SwatchesSection swatches={swatches} error={null} isUpdating={false} />);
+    render(
+      <SwatchesSection
+        swatches={swatches}
+        error={null}
+        isUpdating={false}
+        showOverlay={false}
+      />,
+    );
 
     expect(screen.getAllByRole("article")).toHaveLength(swatches.length);
   });

--- a/app/lib/__tests__/segmentHueSpace.test.ts
+++ b/app/lib/__tests__/segmentHueSpace.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { ColorDescriptor } from "../types.server";
-import { segmentHueSpace } from "../segmentHueSpace.server";
+import { segmentHueSpace, streamSegmentHueSpace } from "../segmentHueSpace.server";
 import { normalizeHue } from "../utils.server";
 
 interface FakeRange {
@@ -120,5 +120,50 @@ describe("segmentHueSpace", () => {
     expect(segments[0].startHue).toBe(0);
     expect(segments[0].endHue).toBe(360);
     expect(calls).toBe(1);
+  });
+
+  it("streams progressive batches of segments", async () => {
+    const stream = streamSegmentHueSpace({
+      saturation: 60,
+      lightness: 50,
+      sample: createFakeSampler([
+        { start: 0, end: 90, name: "Red" },
+        { start: 90, end: 210, name: "Green" },
+        { start: 210, end: 360, name: "Blue" },
+      ]),
+    });
+
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+    }
+
+    buffer += decoder.decode();
+
+    const lines = buffer
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    expect(lines.length).toBeGreaterThan(1);
+
+    const finalPayload = JSON.parse(lines.at(-1) ?? "{}") as {
+      segments: { color: { name: string } }[];
+    };
+
+    expect(finalPayload.segments).toHaveLength(3);
+    expect(finalPayload.segments.map((segment) => segment.color.name)).toEqual([
+      "Red",
+      "Green",
+      "Blue",
+    ]);
   });
 });

--- a/app/lib/defaults.ts
+++ b/app/lib/defaults.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_SATURATION = 60;
+export const DEFAULT_LIGHTNESS = 50;

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,3 +1,6 @@
-import { type RouteConfig, index } from "@react-router/dev/routes";
+import { type RouteConfig, index, route } from "@react-router/dev/routes";
 
-export default [index("routes/_index.tsx")] satisfies RouteConfig;
+export default [
+  index("routes/_index.tsx"),
+  route("swatches.stream", "routes/swatches.stream.ts"),
+] satisfies RouteConfig;

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -6,11 +6,9 @@ import type { Route } from "./+types/_index";
 import { segmentHueSpace } from "~/lib/segmentHueSpace.server";
 import type { HueSegment } from "~/lib/types.server";
 import { normalizeHue, readPercentageParam } from "~/lib/color-utils";
+import { DEFAULT_LIGHTNESS, DEFAULT_SATURATION } from "~/lib/defaults";
 import { SwatchControls } from "~/components/SwatchControls";
 import { SwatchesSection } from "~/components/SwatchesSection";
-
-const DEFAULT_SATURATION = 60;
-const DEFAULT_LIGHTNESS = 50;
 
 export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url);
@@ -34,6 +32,8 @@ export default function Index() {
   const [lValue, setLValue] = useState(lightness);
   const navigation = useNavigation();
   const isUpdatingSwatches = navigation.state !== "idle";
+  const [streamedSegments, setStreamedSegments] = useState(segments);
+  const [hasStreamedPartial, setHasStreamedPartial] = useState(false);
 
   useEffect(() => {
     setSValue(saturation);
@@ -43,10 +43,99 @@ export default function Index() {
     setLValue(lightness);
   }, [lightness]);
 
+  useEffect(() => {
+    setStreamedSegments(segments);
+    setHasStreamedPartial(false);
+  }, [segments]);
+
+  useEffect(() => {
+    if (navigation.state === "idle" || !navigation.location) {
+      return;
+    }
+
+    setHasStreamedPartial(false);
+
+    const controller = new AbortController();
+    const { search } = navigation.location;
+
+    async function streamSegments() {
+      try {
+        const response = await fetch(`/swatches.stream${search}`, {
+          headers: { Accept: "text/x-ndjson" },
+          signal: controller.signal,
+        });
+
+        if (!response.ok || !response.body) {
+          throw new Error(`Unexpected response: ${response.status}`);
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) {
+            break;
+          }
+
+          buffer += decoder.decode(value, { stream: true });
+
+          let newlineIndex = buffer.indexOf("\n");
+          while (newlineIndex !== -1) {
+            const line = buffer.slice(0, newlineIndex).trim();
+            buffer = buffer.slice(newlineIndex + 1);
+
+            if (line) {
+              const payload = JSON.parse(line) as { segments: HueSegment[] };
+              setStreamedSegments(payload.segments);
+              setHasStreamedPartial(true);
+            }
+
+            newlineIndex = buffer.indexOf("\n");
+          }
+        }
+
+        buffer += decoder.decode();
+
+        let newlineIndex = buffer.indexOf("\n");
+        while (newlineIndex !== -1) {
+          const line = buffer.slice(0, newlineIndex).trim();
+          buffer = buffer.slice(newlineIndex + 1);
+
+          if (line) {
+            const payload = JSON.parse(line) as { segments: HueSegment[] };
+            setStreamedSegments(payload.segments);
+            setHasStreamedPartial(true);
+          }
+
+          newlineIndex = buffer.indexOf("\n");
+        }
+
+        const remaining = buffer.trim();
+        if (remaining) {
+          const payload = JSON.parse(remaining) as { segments: HueSegment[] };
+          setStreamedSegments(payload.segments);
+          setHasStreamedPartial(true);
+        }
+      } catch (streamError) {
+        if (!controller.signal.aborted) {
+          console.error("Failed to stream swatches", streamError);
+        }
+      }
+    }
+
+    streamSegments();
+
+    return () => {
+      controller.abort();
+    };
+  }, [navigation.state, navigation.location]);
+
   const swatches = useMemo(() => {
     const seen = new Map<string, HueSegment>();
 
-    for (const segment of segments) {
+    for (const segment of streamedSegments) {
       if (!seen.has(segment.color.name)) {
         seen.set(segment.color.name, segment);
       }
@@ -57,7 +146,9 @@ export default function Index() {
       const rightHue = normalizeHue(right.startHue);
       return leftHue - rightHue;
     });
-  }, [segments]);
+  }, [streamedSegments]);
+
+  const shouldBlockSwatches = isUpdatingSwatches && !hasStreamedPartial;
 
   return (
     <main className="mx-auto w-full max-w-screen-2xl px-4 py-12 sm:px-6 lg:px-10">
@@ -89,6 +180,7 @@ export default function Index() {
         swatches={swatches}
         error={error}
         isUpdating={isUpdatingSwatches}
+        showOverlay={shouldBlockSwatches}
       />
     </main>
   );

--- a/app/routes/swatches.stream.ts
+++ b/app/routes/swatches.stream.ts
@@ -1,0 +1,34 @@
+import type { Route } from "./+types/swatches.stream";
+
+import { streamSegmentHueSpace } from "~/lib/segmentHueSpace.server";
+import { readPercentageParam } from "~/lib/color-utils";
+import { DEFAULT_LIGHTNESS, DEFAULT_SATURATION } from "~/lib/defaults";
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const url = new URL(request.url);
+  const saturation = readPercentageParam(url, "s", DEFAULT_SATURATION);
+  const lightness = readPercentageParam(url, "l", DEFAULT_LIGHTNESS);
+
+  try {
+    const stream = streamSegmentHueSpace({ saturation, lightness });
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/x-ndjson; charset=utf-8",
+        "Cache-Control": "no-cache",
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to stream colors.";
+    const encoder = new TextEncoder();
+    const body = encoder.encode(`${JSON.stringify({ error: message })}\n`);
+
+    return new Response(body, {
+      status: 500,
+      headers: {
+        "Content-Type": "text/x-ndjson; charset=utf-8",
+        "Cache-Control": "no-cache",
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- refactor the hue segmentation routine to emit progress updates and expose a ReadableStream helper
- add a /swatches.stream loader that NDJSON streams batches of segments
- teach the index route to subscribe to the stream, reuse the new defaults module, and keep the grid visible while updates arrive
- adjust the overlay component API and extend tests to cover the streaming path

## Testing
- `npm test`
- `npm run typecheck` *(fails: vitest/vite plugin type mismatch present prior to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dcaac8b930832fac0693282ec49097