### PR TITLE
Implement streaming hue segment updates

### DIFF
--- a/app/components/SwatchesSection.tsx
+++ b/app/components/SwatchesSection.tsx
@@ -17,6 +17,16 @@ const swatchCountMessage = (count: number): string => {
 };
 
 export function SwatchesSection({ swatches, error, isUpdating }: SwatchesSectionProps) {
+  const message = error
+    ? null
+    : swatches.length === 0
+      ? isUpdating
+        ? "Discovering color names…"
+        : "No unique color names were found for this S/L combination."
+      : swatchCountMessage(swatches.length);
+
+  const showOverlay = isUpdating && swatches.length === 0;
+
   return (
     <section className="mt-12">
       <h2 className="text-xl font-semibold text-slate-100">Distinct names</h2>
@@ -25,7 +35,7 @@ export function SwatchesSection({ swatches, error, isUpdating }: SwatchesSection
           Unable to retrieve color names right now: {error}
         </p>
       ) : (
-        <p className="mt-2 text-sm text-slate-400">{swatchCountMessage(swatches.length)}</p>
+        <p className="mt-2 text-sm text-slate-400">{message}</p>
       )}
 
       <div className="relative mt-6" aria-live="polite" aria-busy={isUpdating}>
@@ -34,7 +44,7 @@ export function SwatchesSection({ swatches, error, isUpdating }: SwatchesSection
             <SwatchCard key={segment.color.name} segment={segment} />
           ))}
         </div>
-        {isUpdating && (
+        {showOverlay && (
           <div className="absolute inset-0 flex items-center justify-center rounded-xl border border-white/5 bg-slate-950/60 backdrop-blur-sm">
             <div className="flex items-center gap-3 text-sm font-medium text-slate-200">
               <svg className="h-5 w-5 animate-spin text-slate-200" viewBox="0 0 24 24" aria-hidden="true">

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,3 +1,6 @@
-import { type RouteConfig, index } from "@react-router/dev/routes";
+import { type RouteConfig, index, route } from "@react-router/dev/routes";
 
-export default [index("routes/_index.tsx")] satisfies RouteConfig;
+export default [
+  index("routes/_index.tsx"),
+  route("api/segments", "routes/api.segments.ts"),
+] satisfies RouteConfig;

--- a/app/routes/api.segments.ts
+++ b/app/routes/api.segments.ts
@@ -1,0 +1,29 @@
+import type { LoaderFunctionArgs } from "react-router";
+
+import { segmentHueSpaceStream } from "~/lib/segmentHueSpace.server";
+import { readPercentageParam } from "~/lib/color-utils";
+
+const DEFAULT_SATURATION = 60;
+const DEFAULT_LIGHTNESS = 50;
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const saturation = readPercentageParam(url, "s", DEFAULT_SATURATION);
+  const lightness = readPercentageParam(url, "l", DEFAULT_LIGHTNESS);
+
+  const stream = segmentHueSpaceStream({ saturation, lightness });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}
+
+export const config = {
+  loader: {
+    cache: "no-store" as const,
+  },
+};


### PR DESCRIPTION
## Summary
- add a streaming helper in the hue segmentation module and expose it through a new `/api/segments` loader that emits server-sent events
- teach the index route to subscribe to the stream so swatches fill in progressively and adjust the UI messaging/overlay to account for partial data

## Testing
- npm test
- npm run typecheck *(fails: existing vite/vitest plugin typing mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68dcaac8b930832fac0693282ec49097