### PR TITLE
Fix swatch sorting and disable controls during updates

### DIFF
--- a/app/components/SwatchControls.tsx
+++ b/app/components/SwatchControls.tsx
@@ -29,7 +29,11 @@ export function SwatchControls({
   isDirty,
 }: SwatchControlsProps) {
   return (
-    <Form method="get" className="grid gap-8 rounded-xl border border-white/10 bg-slate-900/40 p-6 shadow-xl backdrop-blur">
+    <Form
+      method="get"
+      preventScrollReset
+      className="grid gap-8 rounded-xl border border-white/10 bg-slate-900/40 p-6 shadow-xl backdrop-blur"
+    >
       <div className="grid gap-6 sm:grid-cols-2">
         <fieldset className="space-y-4">
           <legend className="text-sm font-medium text-slate-200">Saturation</legend>
@@ -43,8 +47,9 @@ export function SwatchControls({
               max={100}
               step={1}
               value={saturationValue}
+              disabled={isUpdating}
               onChange={(event) => onSaturationChange(Number(event.currentTarget.value))}
-              className="accent-slate-200"
+              className="accent-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
             />
             <input
               aria-label="Saturation percentage"
@@ -54,11 +59,12 @@ export function SwatchControls({
               max={100}
               step={1}
               value={saturationValue}
+              disabled={isUpdating}
               onChange={(event) => {
                 const next = clampPercentage(Number(event.currentTarget.value), defaultSaturation);
                 onSaturationChange(next);
               }}
-              className="w-24 rounded-md border border-white/10 bg-slate-950/60 px-3 py-2 text-sm font-medium text-slate-100 shadow-inner focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-400/40"
+              className="w-24 rounded-md border border-white/10 bg-slate-950/60 px-3 py-2 text-sm font-medium text-slate-100 shadow-inner focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-400/40 disabled:cursor-not-allowed disabled:opacity-60"
             />
           </label>
         </fieldset>
@@ -75,8 +81,9 @@ export function SwatchControls({
               max={100}
               step={1}
               value={lightnessValue}
+              disabled={isUpdating}
               onChange={(event) => onLightnessChange(Number(event.currentTarget.value))}
-              className="accent-slate-200"
+              className="accent-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
             />
             <input
               aria-label="Lightness percentage"
@@ -86,11 +93,12 @@ export function SwatchControls({
               max={100}
               step={1}
               value={lightnessValue}
+              disabled={isUpdating}
               onChange={(event) => {
                 const next = clampPercentage(Number(event.currentTarget.value), defaultLightness);
                 onLightnessChange(next);
               }}
-              className="w-24 rounded-md border border-white/10 bg-slate-950/60 px-3 py-2 text-sm font-medium text-slate-100 shadow-inner focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-400/40"
+              className="w-24 rounded-md border border-white/10 bg-slate-950/60 px-3 py-2 text-sm font-medium text-slate-100 shadow-inner focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-400/40 disabled:cursor-not-allowed disabled:opacity-60"
             />
           </label>
         </fieldset>

--- a/app/routes/__tests__/_index.test.ts
+++ b/app/routes/__tests__/_index.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import type { HueSegment } from "~/lib/types.server";
+
+import { sortSwatchesByHue, swatchSortKey } from "../_index";
+
+const createSegment = (
+  name: string,
+  startHue: number,
+  endHue: number,
+): HueSegment => ({
+  startHue,
+  endHue,
+  color: {
+    name,
+    rgb: {
+      value: "#000000",
+      r: 0,
+      g: 0,
+      b: 0,
+    },
+    hsl: {
+      value: `hsl(${startHue} 0% 0%)`,
+      h: startHue,
+      s: 0,
+      l: 0,
+    },
+  },
+});
+
+describe("swatchSortKey", () => {
+  it("returns 0 for segments that wrap around hue 0", () => {
+    const segment = createSegment("wrap", 350, 370);
+    expect(swatchSortKey(segment)).toBe(0);
+  });
+
+  it("normalizes segments that do not wrap", () => {
+    const segment = createSegment("direct", -30, 10);
+    expect(swatchSortKey(segment)).toBe(330);
+  });
+});
+
+describe("sortSwatchesByHue", () => {
+  it("orders wrap-around segments before other hues", () => {
+    const wrap = createSegment("wrap", 350, 380);
+    const other = createSegment("other", 40, 80);
+
+    const result = sortSwatchesByHue([other, wrap]);
+
+    expect(result[0]).toBe(wrap);
+    expect(result[1]).toBe(other);
+  });
+
+  it("falls back to end hue when start hues are equal", () => {
+    const first = createSegment("first", 45, 100);
+    const second = createSegment("second", 45, 90);
+
+    const result = sortSwatchesByHue([first, second]);
+
+    expect(result[0]).toBe(second);
+    expect(result[1]).toBe(first);
+  });
+});
+


### PR DESCRIPTION
## Summary
- prevent the swatch controls form from resetting scroll position and lock inputs while updates are in flight
- ensure hue segments that wrap around 0° sort to the beginning of the swatch list
- cover the new sorting behaviour with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcbae2326c832f9c27e99d7a4afa19