### PR TITLE
Organize server modules under api directory

### DIFF
--- a/app/api/__tests__/segmentHueSpace.test.ts
+++ b/app/api/__tests__/segmentHueSpace.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import type { ColorDescriptor } from "~/shared/types";
+import { collectStreamedSegments, streamSegmentHueSpace } from "../segmentHueSpace.server";
+import { normalizeHue } from "~/shared/color-utils";
+
+interface FakeRange {
+  readonly start: number;
+  readonly end: number;
+  readonly name: string;
+}
+
+const createFakeSampler = (ranges: FakeRange[]) => {
+  return async (hue: number): Promise<ColorDescriptor> => {
+    const normalized = normalizeHue(hue);
+    const match = ranges.find((range) => {
+      if (range.start <= range.end) {
+        return normalized >= range.start && normalized < range.end;
+      }
+
+      return normalized >= range.start || normalized < range.end;
+    });
+
+    const chosen = match ?? ranges[ranges.length - 1];
+    const roundedHue = Number(normalized.toFixed(2));
+
+    return {
+      name: chosen.name,
+      rgb: {
+        value: `rgb(${Math.round(roundedHue)}, 0, 0)`,
+        r: Math.round(roundedHue),
+        g: 0,
+        b: 0,
+      },
+      hsl: {
+        value: `hsl(${roundedHue}, 60%, 50%)`,
+        h: roundedHue,
+        s: 60,
+        l: 50,
+      },
+    } satisfies ColorDescriptor;
+  };
+};
+
+describe("segmentHueSpace", () => {
+  it("splits segments on hue boundaries", async () => {
+    const segments = await collectStreamedSegments({
+      saturation: 60,
+      lightness: 50,
+      sample: createFakeSampler([
+        { start: 0, end: 90, name: "Red" },
+        { start: 90, end: 210, name: "Green" },
+        { start: 210, end: 360, name: "Blue" },
+      ]),
+    });
+
+    expect(segments).toHaveLength(3);
+    expect(segments.map((segment) => segment.color.name)).toEqual([
+      "Red",
+      "Green",
+      "Blue",
+    ]);
+    expect(segments[0].startHue).toBeCloseTo(0, 1);
+    expect(segments[0].endHue).toBeGreaterThan(80);
+    expect(segments[0].endHue).toBeLessThan(100);
+  });
+
+  it("merges wrap-around segments with the same name", async () => {
+    const segments = await collectStreamedSegments({
+      saturation: 60,
+      lightness: 50,
+      sample: createFakeSampler([
+        { start: 0, end: 40, name: "Rose" },
+        { start: 40, end: 300, name: "Gray" },
+        { start: 300, end: 360, name: "Rose" },
+      ]),
+    });
+
+    expect(segments).toHaveLength(2);
+
+    const roseSegment = segments.find(
+      (segment) => segment.color.name === "Rose",
+    );
+
+    expect(roseSegment).toBeDefined();
+    expect(roseSegment?.startHue).toBeGreaterThan(295);
+    expect(roseSegment?.startHue).toBeLessThan(305);
+    expect(roseSegment?.endHue).toBeGreaterThan(360);
+    expect(roseSegment?.endHue).toBeLessThan(406);
+  });
+
+  it("returns a single segment for grayscale values", async () => {
+    let calls = 0;
+    const segments = await collectStreamedSegments({
+      saturation: 0,
+      lightness: 50,
+      sample: async (hue) => {
+        calls += 1;
+        const normalized = Number(normalizeHue(hue).toFixed(2));
+
+        return {
+          name: "Gray",
+          rgb: {
+            value: `rgb(${normalized}, ${normalized}, ${normalized})`,
+            r: normalized,
+            g: normalized,
+            b: normalized,
+          },
+          hsl: {
+            value: `hsl(${normalized}, 0%, 50%)`,
+            h: normalized,
+            s: 0,
+            l: 50,
+          },
+        } satisfies ColorDescriptor;
+      },
+    });
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0].startHue).toBe(0);
+    expect(segments[0].endHue).toBe(360);
+    expect(calls).toBe(1);
+  });
+
+  it("streams progressive batches of segments", async () => {
+    const stream = streamSegmentHueSpace({
+      saturation: 60,
+      lightness: 50,
+      sample: createFakeSampler([
+        { start: 0, end: 90, name: "Red" },
+        { start: 90, end: 210, name: "Green" },
+        { start: 210, end: 360, name: "Blue" },
+      ]),
+    });
+
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+    }
+
+    buffer += decoder.decode();
+
+    const lines = buffer
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    expect(lines.length).toBeGreaterThan(1);
+
+    const finalPayload = JSON.parse(lines.at(-1) ?? "{}") as {
+      segments: { color: { name: string } }[];
+    };
+
+    expect(finalPayload.segments).toHaveLength(3);
+    expect(finalPayload.segments.map((segment) => segment.color.name)).toEqual([
+      "Red",
+      "Green",
+      "Blue",
+    ]);
+  });
+});

--- a/app/api/adaptiveSampler.server.ts
+++ b/app/api/adaptiveSampler.server.ts
@@ -1,0 +1,49 @@
+import type { ColorDescriptor } from "~/shared/types";
+import { normalizeHue } from "~/shared/color-utils";
+
+export class AdaptiveSampler {
+  private readonly fetcher: (hue: number) => Promise<ColorDescriptor>;
+
+  private readonly promises = new Map<number, Promise<ColorDescriptor>>();
+
+  private readonly values = new Map<number, ColorDescriptor>();
+
+  constructor(fetcher: (hue: number) => Promise<ColorDescriptor>) {
+    this.fetcher = fetcher;
+  }
+
+  private keyFor(hue: number): number {
+    const normalized = normalizeHue(hue);
+    return Number(normalized.toFixed(6));
+  }
+
+  async get(hue: number): Promise<ColorDescriptor> {
+    const key = this.keyFor(hue);
+    const existing = this.promises.get(key);
+    if (existing) {
+      return existing;
+    }
+
+    const promise = this.fetcher(normalizeHue(hue)).then((value) => {
+      this.values.set(key, value);
+      return value;
+    });
+
+    this.promises.set(key, promise);
+
+    try {
+      return await promise;
+    } catch (error) {
+      this.promises.delete(key);
+      throw error;
+    }
+  }
+
+  getCached(hue: number): ColorDescriptor | undefined {
+    return this.values.get(this.keyFor(hue));
+  }
+
+  getKnownHues(): number[] {
+    return Array.from(this.values.keys()).sort((a, b) => a - b);
+  }
+}

--- a/app/api/colorApi.server.ts
+++ b/app/api/colorApi.server.ts
@@ -1,0 +1,84 @@
+import type { ColorDescriptor, GetColorByHslOptions } from "~/shared/types";
+import { normalizeHue } from "~/shared/color-utils";
+
+// Base endpoint documented by The Color API for looking up an HSL tuple.
+const COLOR_API_ENDPOINT = "https://www.thecolorapi.com/id";
+
+interface ColorApiResponse {
+  readonly name: { readonly value: string };
+  readonly rgb: {
+    readonly value: string;
+    readonly r: number;
+    readonly g: number;
+    readonly b: number;
+  };
+  readonly hsl: {
+    readonly value: string;
+    readonly h: number;
+    readonly s: number;
+    readonly l: number;
+  };
+}
+
+// Guard against out-of-band saturation/lightness values before building the URL.
+const clampPercentage = (value: number): number => {
+  if (Number.isNaN(value)) {
+    return 0;
+  }
+
+  if (value < 0) {
+    return 0;
+  }
+
+  if (value > 100) {
+    return 100;
+  }
+
+  return value;
+};
+
+// Query The Color API for a single color description at the provided HSL triplet.
+export async function getColorByHsl({
+  hue,
+  saturation,
+  lightness,
+}: GetColorByHslOptions): Promise<ColorDescriptor> {
+  const normalizedHue = normalizeHue(hue);
+  const normalizedSaturation = clampPercentage(saturation);
+  const normalizedLightness = clampPercentage(lightness);
+
+  const url = new URL(COLOR_API_ENDPOINT);
+  url.searchParams.set(
+    "hsl",
+    `${normalizedHue},${normalizedSaturation}%,${normalizedLightness}%`,
+  );
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch color information (${response.status})`);
+  }
+
+  const data = (await response.json()) as ColorApiResponse;
+
+  return {
+    name: data.name.value,
+    rgb: {
+      value: data.rgb.value,
+      r: data.rgb.r,
+      g: data.rgb.g,
+      b: data.rgb.b,
+    },
+    hsl: {
+      value: data.hsl.value,
+      h: data.hsl.h,
+      s: data.hsl.s,
+      l: data.hsl.l,
+    },
+  } satisfies ColorDescriptor;
+}
+

--- a/app/api/segmentHueSpace.server.ts
+++ b/app/api/segmentHueSpace.server.ts
@@ -1,0 +1,282 @@
+import { AdaptiveSampler } from "./adaptiveSampler.server";
+import { getColorByHsl } from "./colorApi.server";
+import type { HueSegment, SegmentHueSpaceOptions } from "~/shared/types";
+
+// Minimum width we will subdivide; narrower bands would be visually indistinguishable.
+const MIN_SPAN = 1;
+
+// Cache keyed by the saturation/lightness tuple to avoid redundant segmentation
+// when computing the full set of segments up front (for SSR or tests).
+// Development rebuilds re-evaluate this module on every request, so the map clears
+// between refreshes; the production build runs inside a long-lived worker where the
+// memo persists and identical S/L pairs reuse the in-flight promise.
+const memo = new Map<string, Promise<HueSegment[]>>();
+
+const buildSegmentsFromKnownHues = (
+  sampler: AdaptiveSampler,
+  knownHues: readonly number[],
+): HueSegment[] => {
+  if (knownHues.length === 0) {
+    return [];
+  }
+
+  const sorted = Array.from(new Set<number>(knownHues))
+    .filter((hue) => hue >= 0 && hue < 360)
+    .sort((a, b) => a - b);
+
+  const segments: HueSegment[] = [];
+
+  for (let index = 0; index < sorted.length; index += 1) {
+    const startHue = sorted[index];
+    const endHue = index + 1 < sorted.length ? sorted[index + 1] : 360;
+    const color = sampler.getCached(startHue);
+
+    if (!color) {
+      continue;
+    }
+
+    segments.push({ startHue, endHue, color });
+  }
+
+  return mergeSegments(segments);
+};
+
+// Kick off adaptive sampling and turn the sampled hues into merged segments,
+// calling `onProgress` whenever a new hue discovery changes the resulting
+// segments.
+async function createSegments(
+  sampler: AdaptiveSampler,
+  saturation: number,
+  lightness: number,
+  onProgress?: (segments: HueSegment[]) => void,
+): Promise<HueSegment[]> {
+  const emit = (segments: HueSegment[]): void => {
+    if (segments.length > 0) {
+      onProgress?.(segments);
+    }
+  };
+
+  if (saturation === 0 || lightness === 0 || lightness === 100) {
+    const color = await sampler.get(0);
+    const grayscale = [
+      {
+        startHue: 0,
+        endHue: 360,
+        color,
+      },
+    ];
+    emit(grayscale);
+    return grayscale;
+  }
+
+  const queue: Array<{ startHue: number; endHue: number }> = [
+    { startHue: 0, endHue: 360 },
+  ];
+
+  await sampler.get(0);
+
+  let lastSignature = "";
+  let lastSegments: HueSegment[] = [];
+
+  const refreshSegments = (): HueSegment[] => {
+    const knownHues = sampler.getKnownHues();
+    const signature = knownHues.join(",");
+    if (signature === lastSignature) {
+      return lastSegments;
+    }
+
+    lastSignature = signature;
+    lastSegments = buildSegmentsFromKnownHues(sampler, knownHues);
+    emit(lastSegments);
+    return lastSegments;
+  };
+
+  refreshSegments();
+
+  while (queue.length > 0) {
+    const { startHue, endHue } = queue.shift()!;
+    const span = endHue - startHue;
+
+    if (span <= MIN_SPAN) {
+      continue;
+    }
+
+    const [startColor, endColor] = await Promise.all([
+      sampler.get(startHue),
+      sampler.get(endHue),
+    ]);
+
+    const midpoint = Math.ceil(startHue + span / 2);
+    const middleColor = await sampler.get(midpoint % 360);
+
+    refreshSegments();
+
+    const namesMatch =
+      startColor.name === middleColor.name &&
+      middleColor.name === endColor.name;
+
+    if (namesMatch) {
+      continue;
+    }
+
+    queue.push({ startHue, endHue: midpoint });
+    queue.push({ startHue: midpoint, endHue });
+  }
+
+  return refreshSegments();
+}
+
+// Combine adjacent segments that map to the same color name, handling wrap-around.
+const mergeSegments = (segments: HueSegment[]): HueSegment[] => {
+  if (segments.length === 0) {
+    return [];
+  }
+
+  const ordered = segments
+    .slice()
+    .sort((left, right) => left.startHue - right.startHue);
+
+  const merged: HueSegment[] = [ordered[0]];
+
+  for (let index = 1; index < ordered.length; index += 1) {
+    const segment = ordered[index];
+    const previous = merged[merged.length - 1];
+
+    if (segment.color.name === previous.color.name) {
+      merged[merged.length - 1] = {
+        ...previous,
+        endHue: segment.endHue,
+      };
+    } else {
+      merged.push(segment);
+    }
+  }
+
+  if (merged.length > 1) {
+    const first = merged[0];
+    const last = merged[merged.length - 1];
+
+    if (first.color.name === last.color.name) {
+      merged[0] = {
+        ...first,
+        startHue: last.startHue,
+        endHue: first.endHue + 360,
+      };
+      merged.pop();
+    }
+  }
+
+  return merged;
+};
+
+export function streamSegmentHueSpace({
+  saturation,
+  lightness,
+  sample,
+}: SegmentHueSpaceOptions): ReadableStream<Uint8Array> {
+  const sampler = new AdaptiveSampler(
+    sample ?? ((hue) => getColorByHsl({ hue, saturation, lightness })),
+  );
+
+  const encoder = new TextEncoder();
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      (async () => {
+        try {
+          await createSegments(sampler, saturation, lightness, (segments) => {
+            const payload = JSON.stringify({ segments });
+            controller.enqueue(encoder.encode(`${payload}\n`));
+          });
+          controller.close();
+        } catch (error) {
+          controller.error(error);
+        }
+      })();
+    },
+  });
+}
+
+async function consumeStream(
+  stream: ReadableStream<Uint8Array>,
+): Promise<HueSegment[]> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let latest: HueSegment[] = [];
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    buffer += decoder.decode(value, { stream: true });
+
+    let newlineIndex = buffer.indexOf("\n");
+    while (newlineIndex !== -1) {
+      const line = buffer.slice(0, newlineIndex).trim();
+      buffer = buffer.slice(newlineIndex + 1);
+
+      if (line) {
+        const payload = JSON.parse(line) as { segments: HueSegment[] };
+        latest = payload.segments;
+      }
+
+      newlineIndex = buffer.indexOf("\n");
+    }
+  }
+
+  buffer += decoder.decode();
+
+  let newlineIndex = buffer.indexOf("\n");
+  while (newlineIndex !== -1) {
+    const line = buffer.slice(0, newlineIndex).trim();
+    buffer = buffer.slice(newlineIndex + 1);
+
+    if (line) {
+      const payload = JSON.parse(line) as { segments: HueSegment[] };
+      latest = payload.segments;
+    }
+
+    newlineIndex = buffer.indexOf("\n");
+  }
+
+  const remaining = buffer.trim();
+  if (remaining) {
+    const payload = JSON.parse(remaining) as { segments: HueSegment[] };
+    latest = payload.segments;
+  }
+
+  return latest;
+}
+
+export async function collectStreamedSegments({
+  saturation,
+  lightness,
+  sample,
+}: SegmentHueSpaceOptions): Promise<HueSegment[]> {
+  if (sample) {
+    return consumeStream(
+      streamSegmentHueSpace({ saturation, lightness, sample }),
+    );
+  }
+
+  const key = `${saturation}:${lightness}`;
+  const cached = memo.get(key);
+  if (cached) {
+    return cached;
+  }
+
+  const promise = consumeStream(
+    streamSegmentHueSpace({ saturation, lightness }),
+  );
+  memo.set(key, promise);
+
+  try {
+    return await promise;
+  } catch (error) {
+    memo.delete(key);
+    throw error;
+  }
+}

--- a/app/components/SwatchCard.tsx
+++ b/app/components/SwatchCard.tsx
@@ -1,5 +1,5 @@
-import type { HueSegment } from "~/lib/types.server";
-import { luminanceTextClass } from "~/lib/color-utils";
+import type { HueSegment } from "~/shared/types";
+import { luminanceTextClass } from "~/shared/color-utils";
 
 interface SwatchCardProps {
   readonly segment: HueSegment;

--- a/app/components/SwatchControls.tsx
+++ b/app/components/SwatchControls.tsx
@@ -1,7 +1,7 @@
 import type { Dispatch, SetStateAction } from "react";
 import { Form } from "react-router";
 
-import { clampPercentage } from "~/lib/color-utils";
+import { clampPercentage } from "~/shared/color-utils";
 
 interface SwatchControlsProps {
   readonly saturation: number;

--- a/app/components/SwatchesSection.tsx
+++ b/app/components/SwatchesSection.tsx
@@ -1,4 +1,4 @@
-import type { HueSegment } from "~/lib/types.server";
+import type { HueSegment } from "~/shared/types";
 
 import { SwatchCard } from "./SwatchCard";
 

--- a/app/components/__tests__/SwatchesSection.test.tsx
+++ b/app/components/__tests__/SwatchesSection.test.tsx
@@ -5,7 +5,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { SwatchesSection } from "../SwatchesSection";
-import type { HueSegment } from "~/lib/types.server";
+import type { HueSegment } from "~/shared/types";
 
 const createSwatch = (name: string): HueSegment => ({
   startHue: 0,

--- a/app/hooks/__tests__/useStreamedSegments.test.tsx
+++ b/app/hooks/__tests__/useStreamedSegments.test.tsx
@@ -2,7 +2,7 @@ import { act, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Location, Navigation } from "react-router";
 
-import type { HueSegment } from "~/lib/types.server";
+import type { HueSegment } from "~/shared/types";
 import { useStreamedSegments } from "../useStreamedSegments";
 import { useEffect } from "react";
 

--- a/app/hooks/useStreamedSegments.ts
+++ b/app/hooks/useStreamedSegments.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import type { Navigation } from "react-router";
 
-import type { HueSegment } from "~/lib/types.server";
+import type { HueSegment } from "~/shared/types";
 
 interface UseStreamedSegmentsArgs {
   readonly navigation: Navigation;

--- a/app/routes/__tests__/_index.test.ts
+++ b/app/routes/__tests__/_index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import type { HueSegment } from "~/lib/types.server";
+import type { HueSegment } from "~/shared/types";
 
 import { sortSwatchesByHue, swatchSortKey } from "../_index";
 

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -3,10 +3,10 @@ import { useLoaderData, useNavigation } from "react-router";
 
 import type { Route } from "./+types/_index";
 
-import { collectStreamedSegments } from "~/lib/segmentHueSpace.server";
-import type { HueSegment } from "~/lib/types.server";
-import { normalizeHue, readPercentageParam } from "~/lib/color-utils";
-import { DEFAULT_LIGHTNESS, DEFAULT_SATURATION } from "~/lib/defaults";
+import { collectStreamedSegments } from "~/api/segmentHueSpace.server";
+import type { HueSegment } from "~/shared/types";
+import { normalizeHue, readPercentageParam } from "~/shared/color-utils";
+import { DEFAULT_LIGHTNESS, DEFAULT_SATURATION } from "~/shared/defaults";
 import { SwatchControls } from "~/components/SwatchControls";
 import { SwatchesSection } from "~/components/SwatchesSection";
 import { useStreamedSegments } from "~/hooks/useStreamedSegments";

--- a/app/routes/swatches.stream.ts
+++ b/app/routes/swatches.stream.ts
@@ -1,8 +1,8 @@
 import type { Route } from "./+types/swatches.stream";
 
-import { streamSegmentHueSpace } from "~/lib/segmentHueSpace.server";
-import { readPercentageParam } from "~/lib/color-utils";
-import { DEFAULT_LIGHTNESS, DEFAULT_SATURATION } from "~/lib/defaults";
+import { streamSegmentHueSpace } from "~/api/segmentHueSpace.server";
+import { readPercentageParam } from "~/shared/color-utils";
+import { DEFAULT_LIGHTNESS, DEFAULT_SATURATION } from "~/shared/defaults";
 
 export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url);

--- a/app/shared/color-utils.ts
+++ b/app/shared/color-utils.ts
@@ -1,0 +1,62 @@
+export const clampPercentage = (value: number, fallback: number): number => {
+  if (Number.isNaN(value)) {
+    return fallback;
+  }
+
+  if (value < 0) {
+    return 0;
+  }
+
+  if (value > 100) {
+    return 100;
+  }
+
+  return value;
+};
+
+export const readPercentageParam = (
+  url: URL,
+  key: string,
+  fallback: number,
+): number => {
+  const values = url.searchParams.getAll(key);
+  const raw = values.at(-1);
+  const numeric = raw === null ? Number.NaN : Number(raw);
+  return clampPercentage(Number.isFinite(numeric) ? numeric : Number.NaN, fallback);
+};
+
+export const normalizeHue = (hue: number): number => {
+  if (!Number.isFinite(hue)) {
+    return 0;
+  }
+
+  const wrapped = hue % 360;
+
+  if (Number.isNaN(wrapped)) {
+    return 0;
+  }
+
+  return wrapped < 0 ? wrapped + 360 : wrapped;
+};
+
+export const luminanceTextClass = ({
+  r,
+  g,
+  b,
+}: {
+  readonly r: number;
+  readonly g: number;
+  readonly b: number;
+}): string => {
+  const toLinear = (value: number): number => {
+    const channel = value / 255;
+    return channel <= 0.03928
+      ? channel / 12.92
+      : Math.pow((channel + 0.055) / 1.055, 2.4);
+  };
+
+  const luminance =
+    0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+
+  return luminance > 0.55 ? "text-slate-900" : "text-slate-50";
+};

--- a/app/shared/defaults.ts
+++ b/app/shared/defaults.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_SATURATION = 60;
+export const DEFAULT_LIGHTNESS = 50;

--- a/app/shared/types.ts
+++ b/app/shared/types.ts
@@ -1,0 +1,35 @@
+export interface ColorDescriptor {
+  readonly name: string;
+  readonly rgb: {
+    readonly value: string;
+    readonly r: number;
+    readonly g: number;
+    readonly b: number;
+  };
+  readonly hsl: {
+    readonly value: string;
+    readonly h: number;
+    readonly s: number;
+    readonly l: number;
+  };
+}
+
+export interface GetColorByHslOptions {
+  readonly hue: number;
+  readonly saturation: number;
+  readonly lightness: number;
+}
+
+export interface HueSegment {
+  readonly startHue: number;
+  readonly endHue: number;
+  readonly color: ColorDescriptor;
+}
+
+export interface SegmentHueSpaceOptions {
+  readonly saturation: number;
+  readonly lightness: number;
+  readonly sample?: (hue: number) => Promise<ColorDescriptor>;
+}
+
+export type ColorSample = ColorDescriptor;


### PR DESCRIPTION
## Summary
- move server-side logic from `app/lib` into a dedicated `app/api` directory
- add a shared module set for color utilities, defaults, and types reused across client and server code
- update components, hooks, and routes to consume the new api and shared entry points

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcbd43c480832fa8649065188b7a25