### PR TITLE
Switch index route to client streaming

### DIFF
--- a/app/api/__tests__/segmentHueSpace.test.ts
+++ b/app/api/__tests__/segmentHueSpace.test.ts
@@ -89,6 +89,24 @@ describe("segmentHueSpace", () => {
     expect(roseSegment?.endHue).toBeLessThan(406);
   });
 
+  it("omits duplicate color names even with punctuation differences", async () => {
+    const segments = await collectStreamedSegments({
+      saturation: 60,
+      lightness: 50,
+      sample: createFakeSampler([
+        { start: 0, end: 90, name: "Screamin Green" },
+        { start: 90, end: 210, name: "Screamin' Green" },
+        { start: 210, end: 270, name: "Screamin Green" },
+        { start: 270, end: 360, name: "Blue" },
+      ]),
+    });
+
+    expect(segments.map((segment) => segment.color.name)).toEqual([
+      "Screamin' Green",
+      "Blue",
+    ]);
+  });
+
   it("returns a single segment for grayscale values", async () => {
     let calls = 0;
     const segments = await collectStreamedSegments({

--- a/app/api/segmentHueSpace.server.ts
+++ b/app/api/segmentHueSpace.server.ts
@@ -182,10 +182,21 @@ export function streamSegmentHueSpace({
 
   return new ReadableStream<Uint8Array>({
     start(controller) {
+      let lastPayload: string | null = null;
+
       (async () => {
         try {
           await createSegments(sampler, saturation, lightness, (segments) => {
+            if (segments.length === 0) {
+              return;
+            }
+
             const payload = JSON.stringify({ segments });
+            if (payload === lastPayload) {
+              return;
+            }
+
+            lastPayload = payload;
             controller.enqueue(encoder.encode(`${payload}\n`));
           });
           controller.close();

--- a/app/api/segmentHueSpace.server.ts
+++ b/app/api/segmentHueSpace.server.ts
@@ -26,6 +26,14 @@ const segmentSpan = ({ startHue, endHue }: HueSegment): number => {
   return endHue + 360 - startHue;
 };
 
+// NOTE: In theory adaptive sampling should already produce unique color names
+// for any given hue, but the upstream dataset occasionally contains
+// near-duplicates (for example, "Screamin' Green" vs "Screamin Green") that
+// lead to overlapping segments being emitted. To guard against these data
+// quirks we canonicalize names, keep only the widest representative span for
+// each canonical key, and then emit at most one segment per key while
+// preserving the original discovery order so incremental updates remain
+// stable.
 const dedupeSegments = (segments: HueSegment[]): HueSegment[] => {
   if (segments.length <= 1) {
     return segments;

--- a/app/hooks/useStreamedSegments.ts
+++ b/app/hooks/useStreamedSegments.ts
@@ -5,39 +5,83 @@ import type { HueSegment } from "~/shared/types";
 
 interface UseStreamedSegmentsArgs {
   readonly navigation: Navigation;
-  readonly initialSegments: HueSegment[];
+  readonly search: string;
 }
 
 interface UseStreamedSegmentsResult {
   readonly segments: HueSegment[];
   readonly hasStreamedPartial: boolean;
+  readonly isStreaming: boolean;
+  readonly error: string | null;
 }
 
 export function useStreamedSegments({
   navigation,
-  initialSegments,
+  search,
 }: UseStreamedSegmentsArgs): UseStreamedSegmentsResult {
-  const [segments, setSegments] = useState(initialSegments);
+  const [segments, setSegments] = useState<HueSegment[]>([]);
   const [hasStreamedPartial, setHasStreamedPartial] = useState(false);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pendingSearch =
+    navigation.state !== "idle" && navigation.location
+      ? navigation.location.search
+      : null;
+  const targetSearch = pendingSearch ?? search ?? "";
 
   useEffect(() => {
-    setSegments(initialSegments);
-    setHasStreamedPartial(false);
-  }, [initialSegments]);
-
-  useEffect(() => {
-    if (navigation.state === "idle" || !navigation.location) {
-      return;
-    }
-
-    setHasStreamedPartial(false);
-
     const controller = new AbortController();
-    const { search } = navigation.location;
+    let isActive = true;
+
+    setSegments([]);
+    setHasStreamedPartial(false);
+    setError(null);
+    setIsStreaming(true);
+
+    const processBuffer = (buffer: string): string => {
+      let working = buffer;
+      let newlineIndex = working.indexOf("\n");
+
+      while (newlineIndex !== -1) {
+        const line = working.slice(0, newlineIndex).trim();
+        working = working.slice(newlineIndex + 1);
+
+        if (line && isActive) {
+          const payload = JSON.parse(line) as {
+            readonly segments?: HueSegment[];
+            readonly error?: string;
+          };
+
+          if (payload.error) {
+            setError(payload.error);
+            setSegments([]);
+            setHasStreamedPartial(false);
+            setIsStreaming(false);
+            controller.abort();
+            return "";
+          }
+
+          if (payload.segments) {
+            setSegments(payload.segments);
+            setHasStreamedPartial(true);
+          }
+        }
+
+        newlineIndex = working.indexOf("\n");
+      }
+
+      return working;
+    };
 
     async function streamSegments() {
       try {
-        const response = await fetch(`/swatches.stream${search}`, {
+        const path = `/swatches.stream${targetSearch}`;
+        const requestUrl =
+          typeof window !== "undefined" && window.location
+            ? new URL(path, window.location.origin).toString()
+            : new URL(path, "http://localhost").toString();
+
+        const response = await fetch(requestUrl, {
           headers: { Accept: "text/x-ndjson" },
           signal: controller.signal,
         });
@@ -57,47 +101,40 @@ export function useStreamedSegments({
           }
 
           buffer += decoder.decode(value, { stream: true });
-
-          let newlineIndex = buffer.indexOf("\n");
-          while (newlineIndex !== -1) {
-            const line = buffer.slice(0, newlineIndex).trim();
-            buffer = buffer.slice(newlineIndex + 1);
-
-            if (line) {
-              const payload = JSON.parse(line) as { segments: HueSegment[] };
-              setSegments(payload.segments);
-              setHasStreamedPartial(true);
-            }
-
-            newlineIndex = buffer.indexOf("\n");
-          }
+          buffer = processBuffer(buffer);
         }
 
         buffer += decoder.decode();
+        buffer = processBuffer(buffer);
 
-        let newlineIndex = buffer.indexOf("\n");
-        while (newlineIndex !== -1) {
-          const line = buffer.slice(0, newlineIndex).trim();
-          buffer = buffer.slice(newlineIndex + 1);
+        const remaining = buffer.trim();
+        if (remaining && isActive) {
+          const payload = JSON.parse(remaining) as {
+            readonly segments?: HueSegment[];
+            readonly error?: string;
+          };
 
-          if (line) {
-            const payload = JSON.parse(line) as { segments: HueSegment[] };
+          if (payload.error) {
+            setError(payload.error);
+            setSegments([]);
+            setHasStreamedPartial(false);
+            setIsStreaming(false);
+          } else if (payload.segments) {
             setSegments(payload.segments);
             setHasStreamedPartial(true);
           }
-
-          newlineIndex = buffer.indexOf("\n");
         }
 
-        const remaining = buffer.trim();
-        if (remaining) {
-          const payload = JSON.parse(remaining) as { segments: HueSegment[] };
-          setSegments(payload.segments);
-          setHasStreamedPartial(true);
+        if (isActive) {
+          setIsStreaming(false);
         }
       } catch (streamError) {
-        if (!controller.signal.aborted) {
+        if (!controller.signal.aborted && isActive) {
           console.error("Failed to stream swatches", streamError);
+          setError(streamError instanceof Error ? streamError.message : "Failed to load colors.");
+          setSegments([]);
+          setHasStreamedPartial(false);
+          setIsStreaming(false);
         }
       }
     }
@@ -105,9 +142,10 @@ export function useStreamedSegments({
     streamSegments();
 
     return () => {
+      isActive = false;
       controller.abort();
     };
-  }, [navigation.state, navigation.location]);
+  }, [targetSearch]);
 
-  return { segments, hasStreamedPartial };
+  return { segments, hasStreamedPartial, isStreaming, error };
 }


### PR DESCRIPTION
## Summary
- remove the index loader and derive saturation/lightness from the URL while rendering
- rework the streaming hook to drive requests itself, clearing stale data and surfacing errors alongside a deduplicated stream
- update the hue streaming tests for the client-driven flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcbf317d58832fa86c022c684d74a3