### PR TITLE
Add swatch entry animation and update README summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,5 @@
-# Welcome to React Router!
+# Color Swatcher
 
-A minimal template for experimenting with React Router v7.
+Color Swatcher is an interactive playground for exploring how hue, saturation, and lightness affect the color names surfaced by the color data service that powers the experience. The interface streams color segments in real time as you experiment with different values, rearranging each swatch by hue so you can quickly scan for interesting combinations without interrupting the flow of new results.
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/remix-run/react-router-templates/tree/main/minimal)
-
-> ![NOTE]
-> This template should not be used for production apps and is intended more for experimentation and demo applications. Please see the [default](https://github.com/remix-run/react-router-templates/tree/main/default) template for a more full-featured template.
-
-## Getting Started
-
-### Installation
-
-Install the dependencies:
-
-```bash
-npm install
-```
-
-### Development
-
-Start the development server with HMR:
-
-```bash
-npm run dev
-```
-
-Your application will be available at `http://localhost:5173`.
-
----
-
-Built with ❤️ using React Router.
+Built with React Router, Vite, and Tailwind CSS, the project showcases modern data loading patterns including optimistic updates, streaming responses, and graceful error states. Use it as a reference implementation for building responsive color-driven experiences or as inspiration for integrating progressive enhancement techniques into your own applications.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,28 @@
 # Color Swatcher
 
-Color Swatcher is an interactive playground for exploring how hue, saturation, and lightness affect the color names surfaced by the color data service that powers the experience. The interface streams color segments in real time as you experiment with different values, rearranging each swatch by hue so you can quickly scan for interesting combinations without interrupting the flow of new results.
+Color Swatcher is an interactive playground for exploring how hue, saturation, and lightness affect the color names surfaced by [the color api](https://www.thecolorapi.com/).
 
-Built with React Router, Vite, and Tailwind CSS, the project showcases modern data loading patterns including optimistic updates, streaming responses, and graceful error states. Use it as a reference implementation for building responsive color-driven experiences or as inspiration for integrating progressive enhancement techniques into your own applications.
+Built with React Router, Vite, and Tailwind CSS, the project showcases modern data loading patterns including optimistic updates, streaming responses, and graceful error states. 
+
+Notable techniques and choices:
+- Use a divide and conquer approach to segment the hue space and display colors; (e.g. we start at the entire hue space, checking 0, 180, and 360, and then subdivide the remaining space into 0-180 and 180-360, etc. and as long as we're seeing new colors, we keep subdividing)
+- Streaming response with ndjson to progressively update the UI as colors are discovered (otherwise it would just sit and load for ~seconds)
+- Use react-router minimalist template as this is not intended to be a production app; used react-router node to handle the "backend for frontend" aspects (if this were more intended for production I'd probably use a heavier template like [Epic Stack](https://github.com/epicweb-dev/epic-stack/tree/main))
+- Not engineered specifically for mobile but the UI is responsive (changes as screen size changes)
+- Note: the source data appears to have some errors, such as including multiple similar color names (e.g. "Screamin' Green" and "Screamin Green" at S/L 97/69) -- some attempts were made to "cleanse" the data on output, but such duplication may affect the fidelity of the results (a bound with color X at a beginning, middle, and endpoint but with a different color Y between those points may not output the color Y)
+- I assumed only whole numbers were relevant here -- the color api is somewhat poorly documented
+
+## To run
+
+- `npm install`
+- `npm run dev`
+
+This should run the app at `http://localhost:5173`.
+
+## To build
+
+- `npm run build`
+
+## To test
+
+- `npm run test`

--- a/app/app.css
+++ b/app/app.css
@@ -1,1 +1,26 @@
 @import "tailwindcss";
+
+@layer components {
+  @keyframes swatch-entry {
+    from {
+      opacity: 0;
+      transform: translateY(0.75rem) scale(0.98);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  .animate-swatch-entry {
+    animation: swatch-entry 260ms cubic-bezier(0.22, 1, 0.36, 1) both;
+    will-change: opacity, transform;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-swatch-entry {
+    animation: none;
+  }
+}

--- a/app/components/SwatchCard.tsx
+++ b/app/components/SwatchCard.tsx
@@ -12,7 +12,7 @@ export function SwatchCard({ segment }: SwatchCardProps) {
   const textClass = luminanceTextClass(rgb);
 
   return (
-    <article className="overflow-hidden rounded-xl border border-white/10 shadow-lg">
+    <article className="animate-swatch-entry overflow-hidden rounded-xl border border-white/10 shadow-lg">
       <div
         className={`p-6 transition-colors duration-300 ${textClass}`}
         style={{ backgroundColor: rgb.value }}


### PR DESCRIPTION
## Summary
- add a subtle entry animation for each swatch and disable it for reduced motion preferences
- replace the template README with a two-paragraph overview of the Color Swatcher project

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dccfddc630832fb11def398a828add